### PR TITLE
Check malloc protection

### DIFF
--- a/fake_malloc/fake_malloc.c
+++ b/fake_malloc/fake_malloc.c
@@ -1,3 +1,4 @@
+#define _GNU_SOURCE
 #include <dlfcn.h>
 #include <sys/errno.h>
 #include <stdlib.h>

--- a/fake_malloc/fake_malloc.c
+++ b/fake_malloc/fake_malloc.c
@@ -1,0 +1,23 @@
+#include <dlfcn.h>
+#include <sys/errno.h>
+#include <stdlib.h>
+
+#ifndef LIMIT
+# define LIMIT 0
+#endif
+
+void	*malloc(size_t size)
+{
+	static void *(*real_malloc)(size_t) = 0;
+	static int counter = 0;
+
+	if (real_malloc == NULL)
+		real_malloc = dlsym(RTLD_NEXT, "malloc");
+	if (counter == LIMIT)
+	{
+		errno = ENOMEM;
+		return (0);
+	}
+	counter++;
+	return (real_malloc(size));
+}

--- a/fake_malloc/fake_malloc.c
+++ b/fake_malloc/fake_malloc.c
@@ -6,6 +6,12 @@
 # define LIMIT 0
 #endif
 
+/*
+	Since libc is a dynamic library, we can overwrite it's functions.
+	What we do is fetch the real malloc function in the library.
+	Then we can either return the value of the real malloc function, or 0.
+	Just like malloc, in case of failure we set errno to ENOMEM.
+*/
 void	*malloc(size_t size)
 {
 	static void *(*real_malloc)(size_t) = 0;

--- a/fake_malloc/fake_malloc.c
+++ b/fake_malloc/fake_malloc.c
@@ -7,15 +7,33 @@
 #endif
 
 /*
-	Since libc is a dynamic library, we can overwrite it's functions.
-	What we do is fetch the real malloc function in the library.
-	Then we can either return the value of the real malloc function, or 0.
-	Just like malloc, in case of failure we set errno to ENOMEM.
+	This code allows us to see what happens in case of malloc failure.
+
+	To use, we just need to add this file to the sources and compile it all together.
+
+	What'll happen is that malloc will be overwritten and each time our project code
+	calls malloc or calloc, these functions below will be called instead.
+
+	This allows us to easily automate testing of malloc-failure after a certain number of
+	mallocs. One problem with this is that it isn't always obvious to trace back what the i-th malloc is.
+
+	TO DO: add realloc function.
+*/
+
+int	counter = 0;
+
+/*
+	Beacuse libc is a dynamic library, we can overwrite it's functions.
+
+	What we do is find the real malloc function in the dynamic library.
+
+	Then we can either:
+		- return the value of the real malloc function.
+		- simulate a malloc failure: set errno to ENOMEM and return 0.
 */
 void	*malloc(size_t size)
 {
 	static void *(*real_malloc)(size_t) = 0;
-	static int counter = 0;
 
 	if (real_malloc == NULL)
 		real_malloc = dlsym(RTLD_NEXT, "malloc");
@@ -26,4 +44,19 @@ void	*malloc(size_t size)
 	}
 	counter++;
 	return (real_malloc(size));
+}
+
+void	*calloc(size_t count, size_t size)
+{
+	static void *(*real_calloc)(size_t, size_t) = 0;
+
+	if (real_calloc == NULL)
+		real_calloc = dlsym(RTLD_NEXT, "calloc");
+	if (counter == LIMIT)
+	{
+		errno = ENOMEM;
+		return (0);
+	}
+	counter++;
+	return (real_calloc(count, size));
 }

--- a/makefile
+++ b/makefile
@@ -23,6 +23,14 @@ tree_ops.c \
 args.c \
 cleanup.c
 
+ifdef CHECK_MALLOC
+	SRCS += fake_malloc/fake_malloc.c
+endif
+
+ifdef LIMIT
+	CFLAGS += -D LIMIT=$(LIMIT)
+endif 
+
 OBJS = $(SRCS:%.c=%.o)
 
 NAME = eval

--- a/makefile
+++ b/makefile
@@ -39,7 +39,7 @@ NAME = eval
 all: $(NAME)
 
 $(NAME): $(OBJS)
-	$(CC) $(CFLAGS) $(OBJS) -lm -o $@
+	$(CC) $(CFLAGS) $(OBJS) -lm -ldl -o $@
 
 clean:
 	$(RM) $(OBJS)

--- a/makefile
+++ b/makefile
@@ -25,13 +25,12 @@ cleanup.c
 
 ifdef CHECK_MALLOC
 	SRCS += fake_malloc/fake_malloc.c
+	CFLAGS += -D LIMIT=$(CHECK_MALLOC)
 endif
 
-ifdef LIMIT
-	CFLAGS += -D LIMIT=$(LIMIT)
-endif 
-
-# Compiling with "make CHECK_MALLOC=1 LIMIT=3" will make sure the 3rd call of malloc will fail. Careful, it doesn't work with calloc, but it shouldn't be difficult to add that feature.
+# To test malloc failure:
+# 	compile with "make CHECK_MALLOC={?}"
+#	This will ensure the ?-th malloc or calloc call will fail.
 
 OBJS = $(SRCS:%.c=%.o)
 

--- a/makefile
+++ b/makefile
@@ -31,6 +31,8 @@ ifdef LIMIT
 	CFLAGS += -D LIMIT=$(LIMIT)
 endif 
 
+# Compiling with "make CHECK_MALLOC=1 LIMIT=3" will make sure the 3rd call of malloc will fail. Careful, it doesn't work with calloc, but it shouldn't be difficult to add that feature.
+
 OBJS = $(SRCS:%.c=%.o)
 
 NAME = eval

--- a/parser.c
+++ b/parser.c
@@ -104,7 +104,6 @@ int	parse_term(char **str, t_tree **left_tree)
 			tmp = create_node(tok, *left_tree, right_tree);
 			if (!tmp)
 			{
-				cleanup_tree(*left_tree);
 				cleanup_tree(right_tree);
 				free(tok);
 			}

--- a/parser.c
+++ b/parser.c
@@ -156,7 +156,6 @@ int parse_factor(char **str, t_tree **tree)
 		tmp = create_node(tok, *tree, 0);
 		if (!tmp)
 		{
-			cleanup_tree(*tree);
 			free(tok);
 			return (-1);
 		}

--- a/parser.c
+++ b/parser.c
@@ -61,7 +61,6 @@ int	parse_expression(char **str, t_tree **left_tree)
 			tmp = create_node(tok, *left_tree, right_tree);
 			if (!tmp)
 			{
-				cleanup_tree(*left_tree);
 				cleanup_tree(right_tree);
 				free(tok);
 				return (-1);


### PR DESCRIPTION
I added some code that might help us check what happens in case of malloc failure.
To use, compile with `make CHECK_MALLOC={?}`. It will emulate what happens if the (?+1)-th malloc or calloc call fails.
For example, `make CHECK_MALLOC=3` will make the fourth call to malloc or calloc fail.